### PR TITLE
Implement mobile modal for User Panel

### DIFF
--- a/_next/static/chunks/249-de437572d43ee045-1.js
+++ b/_next/static/chunks/249-de437572d43ee045-1.js
@@ -1662,10 +1662,11 @@
                       children: "Get started",
                     }),
                     (0, a.jsx)(r.XE, {
-                      onClick: function () {
+                      onClick: function (e) {
                         // Check if mobile device
                         if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || window.innerWidth <= 1024) {
                           // Show mobile modal
+                          e && e.preventDefault && e.preventDefault();
                           const modal = document.getElementById('mobileUserPanelModal');
                           if (modal) {
                             modal.classList.remove('hidden');
@@ -1738,10 +1739,11 @@
                     }),
                     (0, a.jsx)(r.XE, {
                       className: "px-8 py-4 text-4xl",
-                      onClick: function () {
+                      onClick: function (e) {
                         // Check if mobile device
                         if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || window.innerWidth <= 1024) {
                           // Show mobile modal
+                          e && e.preventDefault && e.preventDefault();
                           const modal = document.getElementById('mobileUserPanelModal');
                           if (modal) {
                             modal.classList.remove('hidden');

--- a/_next/static/chunks/249-de437572d43ee045.js
+++ b/_next/static/chunks/249-de437572d43ee045.js
@@ -1662,10 +1662,11 @@
                       children: "Get started",
                     }),
                     (0, a.jsx)(r.XE, {
-                      onClick: function () {
+                      onClick: function (e) {
                         // Check if mobile device
                         if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || window.innerWidth <= 1024) {
                           // Show mobile modal
+                          e && e.preventDefault && e.preventDefault();
                           const modal = document.getElementById('mobileUserPanelModal');
                           if (modal) {
                             modal.classList.remove('hidden');
@@ -1737,10 +1738,11 @@
                       children: "Get started",
                     }),
                     (0, a.jsx)(r.XE, {
-                      onClick: function () {
+                      onClick: function (e) {
                         // Check if mobile device
                         if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || window.innerWidth <= 1024) {
                           // Show mobile modal
+                          e && e.preventDefault && e.preventDefault();
                           const modal = document.getElementById('mobileUserPanelModal');
                           if (modal) {
                             modal.classList.remove('hidden');

--- a/get-invate.html
+++ b/get-invate.html
@@ -784,6 +784,27 @@
     <script>
       (self.__next_f = self.__next_f || []).push([0]);
     </script>
+    <div id="mobileUserPanelModal" class="hidden fixed inset-0 flex items-center justify-center bg-black/80" style="z-index:9999">
+      <div class="bg-white text-black p-6 rounded-lg max-w-sm text-center">
+        <p>This feature is only available on the desktop version of the site. To access the User Panel, please visit the site using a PC.</p>
+        <button id="closeMobileUserPanelModal" class="mt-4 px-4 py-2 bg-magenta text-white rounded">Close</button>
+      </div>
+    </div>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const modal = document.getElementById('mobileUserPanelModal');
+        const closeBtn = document.getElementById('closeMobileUserPanelModal');
+        const hide = () => {
+          modal.classList.add('hidden');
+          document.body.style.overflow = '';
+        };
+        closeBtn.addEventListener('click', hide);
+        modal.addEventListener('click', (e) => {
+          if (e.target === modal) hide();
+        });
+      });
+    </script>
     <script>
       self.__next_f.push([
         1,

--- a/index.htm
+++ b/index.htm
@@ -2320,7 +2320,7 @@
         display: none !important;
       }
     </style>
-    
+
     <script>
       setTimeout(() => {
         const footer = document.querySelector('footer');
@@ -2329,6 +2329,28 @@
           console.log('Footer removed.');
         }
       }, 200); // если не сработает — увеличь задержку до 500-1000 мс
+    </script>
+
+    <div id="mobileUserPanelModal" class="hidden fixed inset-0 flex items-center justify-center bg-black/80" style="z-index:9999">
+      <div class="bg-white text-black p-6 rounded-lg max-w-sm text-center">
+        <p>This feature is only available on the desktop version of the site. To access the User Panel, please visit the site using a PC.</p>
+        <button id="closeMobileUserPanelModal" class="mt-4 px-4 py-2 bg-magenta text-white rounded">Close</button>
+      </div>
+    </div>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const modal = document.getElementById('mobileUserPanelModal');
+        const closeBtn = document.getElementById('closeMobileUserPanelModal');
+        const hide = () => {
+          modal.classList.add('hidden');
+          document.body.style.overflow = '';
+        };
+        closeBtn.addEventListener('click', hide);
+        modal.addEventListener('click', (e) => {
+          if (e.target === modal) hide();
+        });
+      });
     </script>
     
   </body>


### PR DESCRIPTION
## Summary
- add a small modal for mobile users with a notice to use the desktop site
- include JavaScript to close the modal when clicking outside or on the close button
- improve mobile modal click handling in compiled JS bundles
- ensure modal overlay has sufficient z-index on both pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eff8997c8832b80c24c812aa951fd